### PR TITLE
Update release process support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ WORKDIR /usr/src/app
 
 RUN apk --update add git
 
-COPY requirements.txt /usr/src/app/
+COPY dev_requirements.txt /usr/src/app/
 RUN pip install --upgrade pip && \
-    pip install -r requirements.txt
+    pip install -r dev_requirements.txt
 
 COPY . /usr/src/app
 

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,14 @@ all: image
 citest:
 	docker run \
 	  --rm \
+	  --env COVERAGE_FILE=/tmp/coverage.txt \
 	  --env CIRCLECI \
 	  --env CIRCLE_BRANCH \
 	  --env CIRCLE_SHA1 \
 	  --env CODECLIMATE_REPO_TOKEN \
 	  --entrypoint=/bin/sh \
-	  $(IMAGE_NAME) -c 'python setup.py test && codeclimate-test-reporter'
+	  --volume /tmp:/tmp \
+	  $(IMAGE_NAME) -c 'python setup.py test'
 
 image:
 	docker build --tag $(IMAGE_NAME) .
@@ -32,7 +34,7 @@ release: image
 	  --rm \
 	  --volume ~/.pypirc:/home/app/.pypirc \
 	  --entrypoint=/bin/sh \
-	  $(IMAGE_NAME) -c 'bin/release'
+	  $(IMAGE_NAME) -c 'bin/release' && bin/post-release
 
 test-release: image
 	docker run \

--- a/bin/post-release
+++ b/bin/post-release
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# Usage: bin/post-release
+#
+###
+set -e
+
+git tag -f v$(cat reporter/VERSION)
+git push origin --tags

--- a/bin/prep-release
+++ b/bin/prep-release
@@ -43,4 +43,4 @@ else
   echo "hub not installed? Please open the PR manually" >&2
 fi
 
-echo "After merging the version-bump PR, run bin/release"
+echo "After merging the version-bump PR, run: make release"

--- a/bin/release
+++ b/bin/release
@@ -7,10 +7,8 @@
 # Usage: bin/release
 #
 ###
+set -e
 
 python setup.py build
-python setup.py register -r pyp
+python setup.py register -r pypi
 python setup.py sdist upload -r pypi
-
-git tag v$(cat reporter/VERSION)
-git push origin --tags

--- a/circle.yml
+++ b/circle.yml
@@ -4,12 +4,10 @@ machine:
 
 dependencies:
   override:
+    - pip install codeclimate-test-reporter
     - make image
 
 test:
   override:
     - make citest
-
-notify:
-  webhooks:
-    - url: https://cc-slack-proxy.herokuapp.com/circle
+    - codeclimate-test-reporter --file /tmp/coverage.txt

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 requests
-coverage==4.0.3
+coverage>=4.0
 pytest-cov
 pytest
 HTTPretty

--- a/setup.py
+++ b/setup.py
@@ -38,4 +38,5 @@ setup(
         ],
     },
     package_data={"reporter": ["VERSION"]},
+    install_requires=["coverage>=4.0", "requests"],
 )


### PR DESCRIPTION
- Install codeclimate-test-reporter via pip during CircleCI builds (to dogfood)
- Add coverage.py and requests packages as install dependencies
- Fix bin/release script
- Loosen version requirement for coverage.py from ==4.0.3 to >=4.0
