### PR TITLE
Coerce filter result into an iterator

### DIFF
--- a/reporter/components/ci.py
+++ b/reporter/components/ci.py
@@ -12,7 +12,7 @@ class CI:
         return service["matcher"](self.env)
 
     def data(self):
-        service = next(filter(self.predicate, self.__services()), None)
+        service = next(iter(filter(self.predicate, self.__services())), None)
 
         if service:
             return service["data"](self.env)


### PR DESCRIPTION
Fixes the following error from CI#data:

``` console
File "reporter/components/ci.py", line 15, in data
    service = next(filter(self.predicate, iter(self.__services())), None)
TypeError: list object is not an iterator
```
