### PR TITLE
Run test suite on multiple Python versions in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test: image
 	  -it \
 	  --rm \
 	  --entrypoint=/bin/sh \
-	  $(IMAGE_NAME) -c 'python setup.py test'
+	  $(IMAGE_NAME) -c 'python setup.py testcov'
 
 test-release: image
 	docker run \

--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,8 @@
-machine:
-  python:
-    version: 3.5.1
-
 dependencies:
   override:
-    - pip install -r requirements.txt
-    - python setup.py install
+    - pip install tox tox-pyenv
+    - pyenv local 2.7.11 3.4.4 3.5.1
 
 test:
   override:
-    - python setup.py test
-    - codeclimate-test-reporter
+    - tox

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,7 @@ from codeclimate_test_reporter.__init__ import __version__ as reporter_version
 
 
 class RunTests(Command):
-    """Run all tests."""
-    description = 'run tests'
+    description = "Run tests"
     user_options = []
 
     def initialize_options(self):
@@ -16,7 +15,15 @@ class RunTests(Command):
         pass
 
     def run(self):
-        """Run all tests!"""
+        errno = call(["py.test", "tests/"])
+        raise SystemExit(errno)
+
+
+class RunTestsCov(RunTests):
+    description = "Run tests w/ coverage"
+
+    def run(self):
+        """Run all tests with coverage!"""
         errno = call(["py.test", "--cov=codeclimate_test_reporter", "tests/"])
         raise SystemExit(errno)
 
@@ -33,7 +40,7 @@ setup(
     license="MIT",
     packages=find_packages(exclude=["tests"]),
     zip_safe=False,
-    cmdclass={"test": RunTests},
+    cmdclass={"test": RunTests, "testcov": RunTestsCov},
     entry_points={
         "console_scripts": [
             "codeclimate-test-reporter=codeclimate_test_reporter.__main__:run",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist=py27,py34,py35
+
+[testenv]
+commands=python setup.py test
+deps=-rrequirements.txt
+
+[testenv:py35]
+commands=python setup.py testcov
+         python -m codeclimate_test_reporter
+passenv=CODECLIMATE_REPO_TOKEN


### PR DESCRIPTION
This PR updates the CI configuration to install tox and run the test suite against multiple versions of Python. On the version run on Python 3.5, the reporter is executed to send code coverage data to Code Climate.
