### PR TITLE
Open source files with utf-8-sig encoding

### DIFF
--- a/codeclimate_test_reporter/components/file_coverage.py
+++ b/codeclimate_test_reporter/components/file_coverage.py
@@ -8,6 +8,7 @@ if sys.version_info < (3,0):
 
 class FileCoverage:
     def __init__(self, file_node):
+        self.file_body = None
         self.file_node = file_node
         self.__process()
 
@@ -40,10 +41,16 @@ class FileCoverage:
         return self.file_node.findall("lines/line")
 
     def __blob(self):
-        contents = open(self.__filename(), "r", encoding="utf-8-sig").read()
+        contents = self.__file_body()
         header = "blob " + str(len(contents)) + "\0"
 
         return sha1((header + contents).encode("utf-8")).hexdigest()
+
+    def __file_body(self):
+        if not self.file_body:
+            self.file_body = open(self.__filename(), "r", encoding="utf-8-sig").read()
+
+        return self.file_body
 
     def __filename(self):
         return self.file_node.get("filename")
@@ -55,7 +62,7 @@ class FileCoverage:
         return self.__guard_division(self.hits, self.covered)
 
     def __num_lines(self):
-        return sum(1 for line in open(self.__filename()))
+        return len(self.__file_body().splitlines())
 
     def __covered_percent(self):
         return self.__guard_division(self.covered, self.total)

--- a/codeclimate_test_reporter/components/file_coverage.py
+++ b/codeclimate_test_reporter/components/file_coverage.py
@@ -1,5 +1,9 @@
 import json
+import sys
 from hashlib import sha1
+
+if sys.version_info < (3,0):
+    from io import open
 
 
 class FileCoverage:
@@ -36,7 +40,7 @@ class FileCoverage:
         return self.file_node.findall("lines/line")
 
     def __blob(self):
-        contents = open(self.__filename(), "r").read()
+        contents = open(self.__filename(), "r", encoding="utf-8-sig").read()
         header = "blob " + str(len(contents)) + "\0"
 
         return sha1((header + contents).encode("utf-8")).hexdigest()

--- a/codeclimate_test_reporter/components/file_coverage.py
+++ b/codeclimate_test_reporter/components/file_coverage.py
@@ -2,7 +2,7 @@ import json
 import sys
 from hashlib import sha1
 
-if sys.version_info < (3,0):
+if sys.version_info < (3, 0):
     from io import open
 
 

--- a/tests/fixtures/source.py
+++ b/tests/fixtures/source.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 
 
 class Person:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4,7 +4,7 @@ import shutil
 import subprocess
 import sys
 
-if sys.version_info >= (3,0):
+if sys.version_info >= (3, 0):
     from io import StringIO
 else:
     from StringIO import StringIO


### PR DESCRIPTION
Files encoded with `BOM` signatures need a bit more care when they're read and later encoded with `utf-8`. This PR updates the read call to use the `utf-8-sig` encoding to adjust for these `BOM` signatures.

@codeclimate/review :mag_right: