### PR TITLE
Fix Drone CI commit_sha inference

### DIFF
--- a/codeclimate_test_reporter/components/ci.py
+++ b/codeclimate_test_reporter/components/ci.py
@@ -85,7 +85,7 @@ class CI:
                 "build_identifier": self.env.get("CI_BUILD_NUMBER"),
                 "build_url": self.env.get("CI_BUILD_URL"),
                 "branch": self.env.get("CI_BRANCH"),
-                "commit_sha": self.env.get("CI_BUILD_NUMBER"),
+                "commit_sha": self.env.get("CI_COMMIT"),
                 "pull_request": self.env.get("CI_PULL_REQUEST")
             }
         }, {


### PR DESCRIPTION
This mapping is misconfigured to use the CI build number for git commit sha, as
reported in https://github.com/codeclimate/python-test-reporter/issues/23.

@codeclimate/review :mag_right: