### PR TITLE
clarify usage of coverage generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To generate a coverage report with [pytest][], you can use the [pytest-cov][]
 plugin:
 
 ```console
-$ py.test --cov=codeclimate_test_reporter tests/
+$ py.test --cov=your_package tests/
 TOTAL                                                     284     27    90%
 
 ======================== 14 passed in 0.75 seconds ========================
@@ -76,7 +76,7 @@ To generate a coverage report with [nose][], you can use the [nose cover plugin]
 [nose cover plugin]: https://nose.readthedocs.org/en/latest/plugins/cover.html
 
 ```console
-$ nosetests --with-coverage --cover-erase --cover-package=codeclimate_test_reporter
+$ nosetests --with-coverage --cover-erase --cover-package=your_package
 TOTAL                                                284     27    90%
 ----------------------------------------------------------------------
 Ran 14 tests in 0.743s


### PR DESCRIPTION
It took me about two days to realize that --cov=codeclimate_test_reporter isn't supposed to be there in my case, that it's not a magical plugin that gets and sends that report, that it's just the part you want to cover. I'd generally avoid using codeclimate_test_reporter as an example, as it can be confused. If you want a specific example, why not use an existing library that's not self? :)